### PR TITLE
Fix encoding warning in merge script

### DIFF
--- a/scripts/merge_repos_and_check_duplicates.py
+++ b/scripts/merge_repos_and_check_duplicates.py
@@ -36,7 +36,7 @@ def get_files_list(directory, ignore_list):
 
 def get_config_variable(config_name, variable, delimiter):
     ignored_files = []
-    with open(config_name, "r") as config:
+    with open(config_name, "r", encoding="utf-8") as config:
         for line in config:
             if search(variable, line):
                 ignored_files = (


### PR DESCRIPTION
## Summary
- silence pylint W1514 by specifying encoding when reading config

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_684c94fb27308324adf27792dd03c763